### PR TITLE
feat: handle env variable expansion on PATH key

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -296,7 +296,7 @@ namespace Dispatcher {
                 use_showwindow = toBool(config[FLAG_USE_SHOWWINDOW]);
 
 
-            exePath = config[pathKey];
+            exePath = Environment.ExpandEnvironmentVariables(config[pathKey]);
 
             string exefoo = Path.GetFullPath(Path.Combine(dispatcher_dir, exePath));
             if (File.Exists(exefoo))


### PR DESCRIPTION
passing `value="%VAR%"` to `key="ENV_FOO"` works (i.e. expands `VAR`'s value). This PR extends this behavior to `key="PATH"`.